### PR TITLE
Fixed artificially growing disk cache usage

### DIFF
--- a/SDURLCache.m
+++ b/SDURLCache.m
@@ -599,6 +599,8 @@ static dispatch_queue_t get_disk_io_queue() {
     [fileManager release];
     
     dispatch_async_afreentrant(get_disk_cache_queue(), ^{
+        NSNumber *previousCacheItemSize = [[self.diskCacheInfo objectForKey:kAFURLCacheInfoSizesKey] objectForKey:cacheKey];
+        _diskCacheUsage -= [previousCacheItemSize unsignedIntegerValue];
         _diskCacheUsage += [cacheItemSize unsignedIntegerValue];
         [self.diskCacheInfo setObject:[NSNumber numberWithUnsignedInteger:_diskCacheUsage] forKey:kAFURLCacheInfoDiskUsageKey];
         


### PR DESCRIPTION
We also get rid of the `diskUsage` key in the cache info dictionary which could go wrong.
