### PR TITLE
Flush just in-memory cache

### DIFF
--- a/SDURLCache.h
+++ b/SDURLCache.h
@@ -52,4 +52,10 @@
  */
 - (BOOL)isCached:(NSURL *)url;
 
+/*
+ * Clears the receiver’s in-memory cache, removing all stored cached URL responses there.
+ * Has no effect on the on-disk cache.
+ */
+- (void)removeAllCachedResponsesInMemory;
+
 @end

--- a/SDURLCache.m
+++ b/SDURLCache.m
@@ -743,6 +743,10 @@ static dispatch_queue_t get_disk_io_queue() {
     });
 }
 
+- (void)removeAllCachedResponsesInMemory {
+    [super removeAllCachedResponses];
+}
+
 - (BOOL)isCached:(NSURL *)url {
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
     request = [SDURLCache canonicalRequestForRequest:request];


### PR DESCRIPTION
As a supplement to `NSURLCache`, provides a way to clear the contents of the in-memory cache, but not drop the items on disk. (The scenario being responding to a memory warning, where you need to free up storage, but clearing out disk space doesn't have any value.)

This is a slightly naïve implementation that assumes that the Foundation implementation never gains disk caching of its own.
