### PR TITLE
Allow forcing caching of non-cache-using requests.

### DIFF
--- a/SDURLCache.h
+++ b/SDURLCache.h
@@ -38,6 +38,16 @@
  */
 @property (nonatomic, assign) BOOL ignoreMemoryOnlyStoragePolicy;
 
+
+/*
+ * Allow caching responses for a request with a cache policy that ignores the local cache.
+ * Usually, these responses don't need to be cached, because a request that ignores the cache
+ * once is likely to do so every time it is used.
+ * 
+ * The default value is NO.
+ */
+@property (nonatomic, assign) BOOL allowCachingResponsesToNonCachedRequests;
+
 /*
  * Returns a default cache director path to be used at cache initialization. The generated path directory
  * will be located in the application's cache directory and thus won't be synced by iTunes.

--- a/SDURLCache.m
+++ b/SDURLCache.m
@@ -652,9 +652,10 @@ static dispatch_queue_t get_disk_io_queue() {
 - (void)storeCachedResponse:(NSCachedURLResponse *)cachedResponse forRequest:(NSURLRequest *)request {
     request = [SDURLCache canonicalRequestForRequest:request];
     
-    if (request.cachePolicy == NSURLRequestReloadIgnoringLocalCacheData
-        || request.cachePolicy == NSURLRequestReloadIgnoringLocalAndRemoteCacheData
-        || request.cachePolicy == NSURLRequestReloadIgnoringCacheData) {
+    if (!_allowCachingResponsesToNonCachedRequests &&
+        (request.cachePolicy == NSURLRequestReloadIgnoringLocalCacheData
+         || request.cachePolicy == NSURLRequestReloadIgnoringLocalAndRemoteCacheData
+         || request.cachePolicy == NSURLRequestReloadIgnoringCacheData)) {
         // When cache is ignored for read, it's a good idea not to store the result as well as this option
         // have big chance to be used every times in the future for the same request.
         // NOTE: This is a change regarding default URLCache behavior
@@ -784,6 +785,7 @@ static dispatch_queue_t get_disk_io_queue() {
 
 @synthesize minCacheInterval = _minCacheInterval;
 @synthesize ignoreMemoryOnlyStoragePolicy = _ignoreMemoryOnlyStoragePolicy;
+@synthesize allowCachingResponsesToNonCachedRequests = _allowCachingResponsesToNonCachedRequests;
 @synthesize diskCachePath = _diskCachePath;
 @synthesize diskCacheInfo = _diskCacheInfo;
 


### PR DESCRIPTION
Some clients may want to forcibly update the local cache with new data from the server. I first tried to do this by making a request with a cache policy of "always load". However, `SDURLCache` doesn't cache requests to such responses, making that strategy ineffective. 

This pull request adds a property (defaulted to `NO`) that permits caching of responses to requests that ignore the cache. The usual cache policy checks still apply.
