### PR TITLE
Allow SDURLCache to be subclassed instead of hijacking SDURLCache's methods

### DIFF
--- a/SDURLCache.h
+++ b/SDURLCache.h
@@ -10,6 +10,8 @@
 
 #import <Foundation/Foundation.h>
 
+/* Define SDURLCACHE_DEBUG=1 if you want to get some more info about the cached requests. */
+
 @interface SDURLCache : NSURLCache
 {
     @private

--- a/SDURLCache.h
+++ b/SDURLCache.h
@@ -10,14 +10,16 @@
 
 #import <Foundation/Foundation.h>
 
-@interface SDURLCache : NSURLCache {
+@interface SDURLCache : NSURLCache
+{
     @private
-    BOOL _diskCacheInfoDirty;
-    BOOL _ignoreMemoryOnlyStoragePolicy;
-    BOOL _timerPaused;
-    NSUInteger _diskCacheUsage;
-    NSTimeInterval _minCacheInterval;
-    dispatch_source_t _maintenanceTimer;
+        BOOL _diskCacheInfoDirty;
+        BOOL _ignoreMemoryOnlyStoragePolicy;
+        BOOL _timerPaused;
+        BOOL _shouldRespectCacheControlHeaders;
+        NSUInteger _diskCacheUsage;
+        NSTimeInterval _minCacheInterval;
+        dispatch_source_t _maintenanceTimer;
 }
 
 /*
@@ -38,7 +40,6 @@
  */
 @property (nonatomic, assign) BOOL ignoreMemoryOnlyStoragePolicy;
 
-
 /*
  * Allow caching responses for a request with a cache policy that ignores the local cache.
  * Usually, these responses don't need to be cached, because a request that ignores the cache
@@ -47,6 +48,13 @@
  * The default value is NO.
  */
 @property (nonatomic, assign) BOOL allowCachingResponsesToNonCachedRequests;
+
+/*
+ * If the server sends cache-control / pragma: no-cache headers, then the requests will not be cached.
+ *
+ * The default value is YES.
+ */
+@property (nonatomic, assign) BOOL shouldRespectCacheControlHeaders;
 
 /*
  * Returns a default cache director path to be used at cache initialization. The generated path directory
@@ -64,5 +72,17 @@
  * Has no effect on the on-disk cache.
  */
 - (void)removeAllCachedResponsesInMemory;
+
+@end
+
+#pragma mark - For subclasses only
+
+@interface SDURLCache (PrivateMethods)
+
+/*
+ * This is the perfect place to strip some query parameters in case you are sending
+ * OAuth information via query string instead of the Authorization request header.
+ */
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request;
 
 @end

--- a/SDURLCache.m
+++ b/SDURLCache.m
@@ -35,6 +35,7 @@ static NSTimeInterval const kAFURLCacheInfoDefaultMinCacheInterval = 5.0 * 60.0;
 static NSString *const kAFURLCacheInfoFileName = @"cacheInfo.plist";
 static NSString *const kAFURLCacheInfoAccessesKey = @"accesses";
 static NSString *const kAFURLCacheInfoSizesKey = @"sizes";
+static NSString *const kAFURLCacheInfoURLsKey = @"URLs";
 static float const kAFURLCacheLastModFraction = 0.1f; // 10% since Last-Modified suggested by RFC2616 section 13.2.4
 static float const kAFURLCacheDefault = 3600.0f; // Default cache expiration delay if none defined (1 hour)
 
@@ -419,7 +420,7 @@ static dispatch_queue_t get_disk_io_queue() {
     // Define "now" based on the request
     NSString *date = [headers objectForKey:@"Date"];
     // If no Date: header, define now from local clock
-    NSDate *now = date ? [SDURLCache dateFromHttpDateString:date] : [NSDate date];
+    NSDate *now = date ? [[self class] dateFromHttpDateString:date] : [NSDate date];
     
     // Look at info from the Cache-Control: max-age=n header
     NSString *cacheControl = [[headers objectForKey:@"Cache-Control"] lowercaseString];
@@ -447,7 +448,7 @@ static dispatch_queue_t get_disk_io_queue() {
     NSString *expires = [headers objectForKey:@"Expires"];
     if (expires) {
         NSTimeInterval expirationInterval = 0;
-        NSDate *expirationDate = [SDURLCache dateFromHttpDateString:expires];
+        NSDate *expirationDate = [[self class] dateFromHttpDateString:expires];
         if (expirationDate) {
             expirationInterval = [expirationDate timeIntervalSinceDate:now];
         }
@@ -470,7 +471,7 @@ static dispatch_queue_t get_disk_io_queue() {
     NSString *lastModified = [headers objectForKey:@"Last-Modified"];
     if (lastModified) {
         NSTimeInterval age = 0;
-        NSDate *lastModifiedDate = [SDURLCache dateFromHttpDateString:lastModified];
+        NSDate *lastModifiedDate = [[self class] dateFromHttpDateString:lastModified];
         if (lastModifiedDate) {
             // Define the age of the document by comparing the Date header with the Last-Modified header
             age = [now timeIntervalSinceDate:lastModifiedDate];
@@ -491,6 +492,9 @@ static dispatch_queue_t get_disk_io_queue() {
                     _diskCacheInfo = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
                                       [NSMutableDictionary dictionary], kAFURLCacheInfoAccessesKey,
                                       [NSMutableDictionary dictionary], kAFURLCacheInfoSizesKey,
+#if SDURLCACHE_DEBUG
+                                      [NSMutableDictionary dictionary], kAFURLCacheInfoURLsKey,
+#endif
                                       nil];
                 }
                 _diskCacheInfoDirty = NO;
@@ -541,12 +545,18 @@ static dispatch_queue_t get_disk_io_queue() {
             
             NSMutableDictionary *accesses = [self.diskCacheInfo objectForKey:kAFURLCacheInfoAccessesKey];
             NSMutableDictionary *sizes = [self.diskCacheInfo objectForKey:kAFURLCacheInfoSizesKey];
+#if SDURLCACHE_DEBUG
+            NSMutableDictionary *urls = [self.diskCacheInfo objectForKey:kAFURLCacheInfoURLsKey];
+#endif
             NSFileManager *fileManager = [[NSFileManager alloc] init];
             
             while ((cacheKey = [enumerator nextObject])) {
                 NSUInteger cacheItemSize = [[sizes objectForKey:cacheKey] unsignedIntegerValue];
                 [accesses removeObjectForKey:cacheKey];
                 [sizes removeObjectForKey:cacheKey];
+#if SDURLCACHE_DEBUG
+                [urls removeObjectForKey:cacheKey];
+#endif
                 [fileManager removeItemAtPath:[_diskCachePath stringByAppendingPathComponent:cacheKey] error:NULL];
                 
                 _diskCacheUsage -= cacheItemSize;
@@ -583,7 +593,7 @@ static dispatch_queue_t get_disk_io_queue() {
 
 
 - (void)storeRequestToDisk:(NSURLRequest *)request response:(NSCachedURLResponse *)cachedResponse {
-    NSString *cacheKey = [SDURLCache cacheKeyForURL:request.URL];
+    NSString *cacheKey = [[self class] cacheKeyForURL:request.URL];
     NSString *cacheFilePath = [_diskCachePath stringByAppendingPathComponent:cacheKey];
     
     [self createDiskCachePath];
@@ -606,6 +616,9 @@ static dispatch_queue_t get_disk_io_queue() {
         // Update cache info for the stored item
         [(NSMutableDictionary *)[self.diskCacheInfo objectForKey:kAFURLCacheInfoAccessesKey] setObject:[NSDate date] forKey:cacheKey];
         [(NSMutableDictionary *)[self.diskCacheInfo objectForKey:kAFURLCacheInfoSizesKey] setObject:cacheItemSize forKey:cacheKey];
+#if SDURLCACHE_DEBUG
+        [(NSMutableDictionary *)[self.diskCacheInfo objectForKey:kAFURLCacheInfoURLsKey] setObject:request.URL.absoluteString forKey:cacheKey];
+#endif
         
         [self saveCacheInfo];
         
@@ -652,7 +665,7 @@ static dispatch_queue_t get_disk_io_queue() {
 }
 
 - (void)storeCachedResponse:(NSCachedURLResponse *)cachedResponse forRequest:(NSURLRequest *)request {
-    request = [SDURLCache canonicalRequestForRequest:request];
+    request = [[self class] canonicalRequestForRequest:request];
     
     if (!_allowCachingResponsesToNonCachedRequests &&
         (request.cachePolicy == NSURLRequestReloadIgnoringLocalCacheData
@@ -676,7 +689,7 @@ static dispatch_queue_t get_disk_io_queue() {
             NSDictionary *headers = [(NSHTTPURLResponse *)cachedResponse.response allHeaderFields];
             // RFC 2616 section 13.3.4 says clients MUST use Etag in any cache-conditional request if provided by server
             if (![headers objectForKey:@"Etag"]) {
-                NSDate *expirationDate = [SDURLCache expirationDateFromHeaders:headers
+                NSDate *expirationDate = [[self class] expirationDateFromHeaders:headers
                                                                 withStatusCode:((NSHTTPURLResponse *)cachedResponse.response).statusCode];
                 if (!expirationDate || [expirationDate timeIntervalSinceNow] - _minCacheInterval <= 0) {
                     // This response is not cacheable, headers said
@@ -692,14 +705,14 @@ static dispatch_queue_t get_disk_io_queue() {
 }
 
 - (NSCachedURLResponse *)cachedResponseForRequest:(NSURLRequest *)request {
-    request = [SDURLCache canonicalRequestForRequest:request];
+    request = [[self class] canonicalRequestForRequest:request];
     
     NSCachedURLResponse *memoryResponse = [super cachedResponseForRequest:request];
     if (memoryResponse) {
         return memoryResponse;
     }
     
-    NSString *cacheKey = [SDURLCache cacheKeyForURL:request.URL];
+    NSString *cacheKey = [[self class] cacheKeyForURL:request.URL];
     
     // NOTE: We don't handle expiration here as even staled cache data is necessary for NSURLConnection to handle cache revalidation.
     //       Staled cache data is also needed for cachePolicies which force the use of the cache.
@@ -744,10 +757,10 @@ static dispatch_queue_t get_disk_io_queue() {
 }
 
 - (void)removeCachedResponseForRequest:(NSURLRequest *)request {
-    request = [SDURLCache canonicalRequestForRequest:request];
+    request = [[self class] canonicalRequestForRequest:request];
     
     [super removeCachedResponseForRequest:request];
-    [self removeCachedResponseForCachedKeys:[NSArray arrayWithObject:[SDURLCache cacheKeyForURL:request.URL]]];
+    [self removeCachedResponseForCachedKeys:[NSArray arrayWithObject:[[self class] cacheKeyForURL:request.URL]]];
     [self saveCacheInfo];
 }
 
@@ -766,12 +779,12 @@ static dispatch_queue_t get_disk_io_queue() {
 
 - (BOOL)isCached:(NSURL *)url {
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
-    request = [SDURLCache canonicalRequestForRequest:request];
+    request = [[self class] canonicalRequestForRequest:request];
     
     if ([super cachedResponseForRequest:request]) {
         return YES;
     }
-    NSString *cacheKey = [SDURLCache cacheKeyForURL:url];
+    NSString *cacheKey = [[self class] cacheKeyForURL:url];
     NSString *cacheFile = [_diskCachePath stringByAppendingPathComponent:cacheKey];
     
     BOOL isCached = [[[NSFileManager alloc] init] fileExistsAtPath:cacheFile];

--- a/SDURLCache.xcodeproj/project.pbxproj
+++ b/SDURLCache.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -163,8 +163,11 @@
 /* Begin PBXProject section */
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0460;
+			};
 			buildConfigurationList = 1DEB922208733DC00010E9CD /* Build configuration list for PBXProject "SDURLCache" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -246,7 +249,6 @@
 				COPY_PHASE_STRIP = NO;
 				DSTROOT = /tmp/SDURLCache.dst;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -348,7 +350,6 @@
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
 				);
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				OTHER_LDFLAGS = (
@@ -359,7 +360,6 @@
 					"-framework",
 					UIKit,
 				);
-				PREBINDING = NO;
 				PRODUCT_NAME = SDURLCacheTestBundle;
 				SDKROOT = iphoneos;
 				WRAPPER_EXTENSION = octest;
@@ -377,7 +377,6 @@
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
 				);
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
 				INFOPLIST_FILE = "SDURLCacheTestBundle-Info.plist";
 				OTHER_LDFLAGS = (
@@ -388,7 +387,6 @@
 					"-framework",
 					UIKit,
 				);
-				PREBINDING = NO;
 				PRODUCT_NAME = SDURLCacheTestBundle;
 				SDKROOT = iphoneos;
 				WRAPPER_EXTENSION = octest;


### PR DESCRIPTION
There are some times when you need to strip out some query parameters like oauth_timestamp, oauth_signature, etc. In my particular case this is the only auth method possible, via query string because the server doesn't provide support for Authorization header auth and because of that I've added the following things to help me cache some requests.

Added shouldRespectCacheControlHeaders property and PrivateMethods category for subclasses.

Added some debugging info and made the canonicalRequestForRequest: method to be called in subclasses.
