### PR TITLE
remove dispatch_release() call

### DIFF
--- a/SDURLCache.m
+++ b/SDURLCache.m
@@ -778,7 +778,6 @@ static dispatch_queue_t get_disk_io_queue() {
 - (void)dealloc {
     if(_maintenanceTimer) {
         dispatch_source_cancel(_maintenanceTimer);
-        dispatch_release(_maintenanceTimer);
     }
     _diskCachePath = nil;
     _diskCacheInfo = nil;


### PR DESCRIPTION
remove dispatch_release() call since ARC handles it (and forbids directly calling it) in iOS 6+
