### PR TITLE
Don't assume there is a single SDURLCache instance per application

### DIFF
--- a/SDURLCache.m
+++ b/SDURLCache.m
@@ -511,8 +511,7 @@ static dispatch_queue_t get_disk_io_queue() {
 }
 
 - (void)createDiskCachePath {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
+    @synchronized(self) {
         NSFileManager *fileManager = [[NSFileManager alloc] init];
         if (![fileManager fileExistsAtPath:_diskCachePath]) {
             [fileManager createDirectoryAtPath:_diskCachePath
@@ -520,7 +519,7 @@ static dispatch_queue_t get_disk_io_queue() {
                                     attributes:nil
                                          error:NULL];
         }
-    });
+    }
 }
 
 - (void)saveCacheInfo {

--- a/SDURLCache.podspec
+++ b/SDURLCache.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name     = 'SDURLCache'
+  s.version  = '0.1'
+  s.license  = 'MIT'
+  s.summary  = 'URLCache subclass with on-disk cache support on iPhone/iPad. Forked for speed!'
+  s.homepage = 'https://github.com/pierlis/SDURLCache'
+  s.author   = 'Peter Steinberger'
+  s.source   = { :git => 'https://github.com/pierlis/SDURLCache.git', :tag => 'v0.1' }
+  s.requires_arc = true
+  s.source_files = 'SDURLCache.{h,m}'
+end


### PR DESCRIPTION
Hi,

I'm using SDURLCache in order to control the cache cleanup: thanks for the nice work.

And I'm using several SDURLCache instances across my whole application. Unfortunately, [SDURLCache createDiskCachePath] uses dispatch_once for creating the cache directory once and for all. The problem is that all instances but one will fail storing their cachedURLResponse, since they could not create their own directory on disk.

I don't expect this commit to be accepted as is : it's a very naive fix, and a mere request for comment.
